### PR TITLE
Fix apostrophe in Ender's Game book title

### DIFF
--- a/src/app/Labs/Lab1/page.tsx
+++ b/src/app/Labs/Lab1/page.tsx
@@ -67,7 +67,7 @@ export default function Lab1() {
         <ul id="wd-my-books">
           <li>Dune</li>
           <li>Lord of the Rings</li>
-          <li>Ender's Game</li>
+          <li>Ender&apos;s Game</li>
           <li>Red Mars</li>
           <li>The Forever War</li>
         </ul>


### PR DESCRIPTION
Eslint error build the HTML entity &apos; in 'Ender's Game'